### PR TITLE
Fix `pastgigs` path

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,11 @@ docsifyで色々ためしてみる。GitHub Pagesでホストしたデモペー�
 [https://pistachiostudio.github.io/pistachio-on-docsify/](https://pistachiostudio.github.io/pistachio-on-docsify/)
 
 ![image](https://user-images.githubusercontent.com/4445606/179336234-77d5e794-be38-41cb-b589-e2cd5e336a74.png)
+
+## Development
+
+use [docsify](https://docsify.js.org/#/quickstart)
+
+```
+docsify serve docs
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 ### Upcoming Party
 
 There is nothing going on. L(@_@;)  
-[Past Parties>>>](/pastgigs)  
+[Past Parties>>>](/pistachio-on-docsify/pastgigs)  
 
 If you want more information, follow us on Instagram or Twitter!!
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,7 +48,6 @@
   <!-- docsicy main settings-->>
   <script>
     window.$docsify = {
-      basePath: '/pistachio-on-docsify/',
       hideSidebar: true,
       name: 'Pistachio Studio',
       routerMode: 'history',

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,6 +48,7 @@
   <!-- docsicy main settings-->>
   <script>
     window.$docsify = {
+      basePath: '/pistachio-on-docsify/',
       hideSidebar: true,
       name: 'Pistachio Studio',
       routerMode: 'history',


### PR DESCRIPTION
一応ページ遷移はできるのですが、遷移後にページのリロードをするとおれの環境では404ページが表示されてしまいました。

それ以外は問題ないかと思います。

**補足**

このパスの問題はおそらくGitHubPagesの仕様の影響もあるとは思うので、別のホスティングサービスを使った場合は再度パスの修正が必要になるかもしれません。

GitHubPagesで運用している間はOKだと思います。

**Forkしてテストしたやつ**

- https://zztkm.github.io/pistachio-on-docsify/